### PR TITLE
Fixing statsmodule due to https://github.com/thirtybees/thirtybees/pull/1598/commits

### DIFF
--- a/stats/statsordersprofit.php
+++ b/stats/statsordersprofit.php
@@ -151,17 +151,16 @@ class StatsOrdersProfit extends StatsModule
     {
         $currency = new Currency(Configuration::get('PS_CURRENCY_DEFAULT'));
         $date_between = $this->getDate();
-        $array_date_between = explode(' AND ', $date_between);
 
         $this->query = 'SELECT o.id_order as number, o.invoice_number as invoice_number, DATE_FORMAT(o.invoice_date, \'%Y-%m-%d\') as invoice_date, ROUND( o.total_paid / o.conversion_rate , 2 ) as paid,  ROUND((o.total_paid / o.conversion_rate + o.total_discounts_tax_incl / o.conversion_rate), 2 ) as total, ROUND((o.total_paid / o.conversion_rate - total_paid_tax_excl / o.conversion_rate) , 2 ) as TaxTotal, ROUND( o.total_shipping_tax_excl / o.conversion_rate , 2 ) AS shipping, ROUND(SUM(o.total_discounts_tax_incl / o.conversion_rate),2) as totalDiscount, ((
-			SELECT ROUND(SUM(p.wholesale_price / o.conversion_rate * od.product_quantity / o.conversion_rate), 2)
+			SELECT ROUND(SUM(od.original_wholesale_price / o.conversion_rate * od.product_quantity), 2)
                         FROM '._DB_PREFIX_.'order_detail od
 			LEFT JOIN '._DB_PREFIX_.'product p ON od.product_id = p.id_product
 			LEFT JOIN '._DB_PREFIX_.'product_attribute pa ON pa.id_product_attribute = od.product_attribute_id
 			WHERE od.id_order = o.`id_order`
 			)) AS cost,
 			((
-			SELECT ROUND(o.`total_paid` / o.conversion_rate  - SUM(p.wholesale_price / o.conversion_rate * od.product_quantity) , 2)
+			SELECT ROUND(o.`total_paid` / o.conversion_rate - SUM(od.original_wholesale_price / o.conversion_rate * od.product_quantity) , 2)
 			FROM '._DB_PREFIX_.'order_detail od
 			LEFT JOIN '._DB_PREFIX_.'product p ON od.product_id = p.id_product
 			LEFT JOIN '._DB_PREFIX_.'product_attribute pa ON pa.id_product_attribute = od.product_attribute_id

--- a/statsmodule.php
+++ b/statsmodule.php
@@ -882,13 +882,13 @@ class StatsModule extends ModuleStats
 						IFNULL(SUM(
 							CASE
 								WHEN cp.`original_wholesale_price` <> "0.000000"
-								THEN cp.`original_wholesale_price` * cp.`product_quantity`
+								THEN cp.`original_wholesale_price` / o.`conversion_rate` * cp.`product_quantity`
 								WHEN pa.`wholesale_price` <> "0.000000"
 								THEN pa.`wholesale_price` * cp.`product_quantity`
 								WHEN pr.`wholesale_price` <> "0.000000"
 								THEN pr.`wholesale_price` * cp.`product_quantity`
 							END
-						), 0) / o.conversion_rate AS totalWholeSalePriceSold
+						), 0) AS totalWholeSalePriceSold
 					FROM `'._DB_PREFIX_.'product` pr
 					LEFT OUTER JOIN `'._DB_PREFIX_.'order_detail` cp ON pr.`id_product` = cp.`product_id`
 					LEFT JOIN `'._DB_PREFIX_.'orders` o ON o.`id_order` = cp.`id_order`


### PR DESCRIPTION
As we want to store all numbers in oder_detail table in the order currency, I have made this commit: https://github.com/thirtybees/thirtybees/pull/1598/commits

This is asking for some adjustments in the statsmodule as well. 

Note, that this commit also fixes a stupid behaviour: the module used p.wholesale_price to calculate orderprofits. This is just wrong. Actually od.original_wholesale_price is exactly for this purpose. Otherwise the profit on an order changes always when the wholesale_price changes (can happen years later for example)...